### PR TITLE
Big operator support.

### DIFF
--- a/core/libtexpdf-output.lua
+++ b/core/libtexpdf-output.lua
@@ -136,14 +136,14 @@ SILE.outputters.libtexpdf = {
   debugHbox = function(hbox, scaledWidth)
     ensureInit()
     pdf.colorpush_rgb(0.8, 0.3, 0.3)
-    pdf.setrule(cursorX,cursorY+(hbox.height), scaledWidth+0.5, 0.5)
-    pdf.setrule(cursorX,cursorY, 0.5, hbox.height)
-    pdf.setrule(cursorX, cursorY, scaledWidth+0.5, 0.5)
-    pdf.setrule(cursorX+scaledWidth,cursorY, 0.5, hbox.height)
+    pdf.setrule(cursorX,cursorY+(hbox.height), scaledWidth+0.1, 0.1)
+    pdf.setrule(cursorX,cursorY, 0.1, hbox.height)
+    pdf.setrule(cursorX, cursorY, scaledWidth+0.1, 0.1)
+    pdf.setrule(cursorX+scaledWidth,cursorY, 0.1, hbox.height)
     if hbox.depth then
-      pdf.setrule(cursorX,cursorY-(hbox.depth), scaledWidth, 0.5)
-      pdf.setrule(cursorX+scaledWidth,cursorY-(hbox.depth), 0.5, hbox.depth)
-      pdf.setrule(cursorX,cursorY-(hbox.depth), 0.5, hbox.depth)
+      pdf.setrule(cursorX,cursorY-(hbox.depth), scaledWidth, 0.1)
+      pdf.setrule(cursorX+scaledWidth,cursorY-(hbox.depth), 0.1, hbox.depth)
+      pdf.setrule(cursorX,cursorY-(hbox.depth), 0.1, hbox.depth)
 
     end
     pdf.colorpop()

--- a/core/math.lua
+++ b/core/math.lua
@@ -261,32 +261,34 @@ local _stackbox = _mbox {
     if self.anchor < 1 or self.anchor > #(self.children) then
       SU.error('Wrong index of the anchor children')
     end
-    -- Add space between Ord and Bin/Rel
-    local spaces = {}
-    if self.mode == mathMode.display or self.mode == mathMode.displayCramped or
-        self.mode == mathMode.text or self.mode == mathMode.textCramped then
-      for i, v in ipairs(self.children) do
-        if i < #self.children then
-          local v2 = self.children[i + 1]
-          if (v.atom == atomType.relationalOperator and v2.atom == atomType.ordinary) or
-              (v2.atom == atomType.relationalOperator and v.atom == atomType.ordinary) then
-            spaces[i + 1] = 'thick'
-          elseif (v.atom == atomType.binaryOperator and v2.atom == atomType.ordinary) or
-              (v2.atom == atomType.binaryOperator and v.atom == atomType.ordinary) then
-            spaces[i + 1] = 'med'
+    if self.direction == "H" then
+      -- Add space between Ord and Bin/Rel
+      local spaces = {}
+      if self.mode == mathMode.display or self.mode == mathMode.displayCramped or
+          self.mode == mathMode.text or self.mode == mathMode.textCramped then
+        for i, v in ipairs(self.children) do
+          if i < #self.children then
+            local v2 = self.children[i + 1]
+            if (v.atom == atomType.relationalOperator and v2.atom == atomType.ordinary) or
+                (v2.atom == atomType.relationalOperator and v.atom == atomType.ordinary) then
+              spaces[i + 1] = 'thick'
+            elseif (v.atom == atomType.binaryOperator and v2.atom == atomType.ordinary) or
+                (v2.atom == atomType.binaryOperator and v.atom == atomType.ordinary) then
+              spaces[i + 1] = 'med'
+            end
           end
         end
       end
-    end
 
-    local spaceIdx = {}
-    for i, _ in pairs(spaces) do
-      table.insert(spaceIdx, i)
-    end
-    table.sort(spaceIdx, function(a, b) return a > b end)
-    for _, idx in ipairs(spaceIdx) do
-      table.insert(self.children, idx, newSpace({kind = spaces[idx]}))
-      if idx <= self.anchor then self.anchor = self.anchor + 1 end
+      local spaceIdx = {}
+      for i, _ in pairs(spaces) do
+        table.insert(spaceIdx, i)
+      end
+      table.sort(spaceIdx, function(a, b) return a > b end)
+      for _, idx in ipairs(spaceIdx) do
+        table.insert(self.children, idx, newSpace({kind = spaces[idx]}))
+        if idx <= self.anchor then self.anchor = self.anchor + 1 end
+      end
     end
   end,
   styleChildren = function(self)
@@ -439,7 +441,8 @@ local _space = _terminal {
   kind = "thin",
   init = function(self)
     _terminal.init(self)
-    local mu = self.options.size / 18
+    local fontSize = math.floor(self.options.size * ((self.mode == mathMode.script or self.mode == mathMode.scriptCramped) and 0.7 or 0.5))
+    local mu = fontSize / 18
     if self.kind == "thin" then
       self.length = SILE.length.new({
         length = 3 * mu,
@@ -464,7 +467,9 @@ local _space = _terminal {
   end,
   shape = function(self)
     self.width = self.length
-    self.height = self.options.size
+    -- Spaces say that they have height zero because they cannot guess
+    -- what the maximum height in the surrounding text is
+    self.height = 0
     self.depth = 0
   end,
   output = function(self) end

--- a/core/math.lua
+++ b/core/math.lua
@@ -202,8 +202,8 @@ local _mbox = _box {
   _type = "Mbox",
   options = {},
   children = {}, -- The child nodes
-  relX = 0, -- x position relative to its parent box
-  relY = 0, -- y position relative to its parent box
+  relX = SILE.length.make(0), -- x position relative to its parent box
+  relY = SILE.length.make(0), -- y position relative to its parent box
   value = {},
   mode = mathMode.display,
   atom = atomType.ordinary,
@@ -574,8 +574,8 @@ local _space = _terminal {
     self.width = self.length
     -- Spaces say that they have height zero because they cannot guess
     -- what the maximum height in the surrounding text is
-    self.height = 0
-    self.depth = 0
+    self.height = SILE.length.make(0)
+    self.depth = SILE.length.make(0)
   end,
   output = function(self) end
 }

--- a/core/math.lua
+++ b/core/math.lua
@@ -480,6 +480,11 @@ local _bigOpSubscript = _subscript {
     return 0
   end,
   shape = function(self)
+    if not (self.mode == mathMode.display
+        or self.mode == mathMode.displayCramped) then
+      _subscript.shape(self)
+      return
+    end
     local constants = getMathMetrics(self.options).constants
     -- Determine relative Ys
     if self.base then

--- a/core/math.lua
+++ b/core/math.lua
@@ -661,7 +661,7 @@ local _text = _terminal {
   output = function(self, x, y, line)
     if not self.value.glyphString then return end
     -- print('Output '..self.value.glyphString.." to "..x..", "..y)
-    SILE.outputter.moveTo(getNumberFromLength(x, line), getNumberFromLength(y, line))
+    SILE.outputter.moveTo(getNumberFromLength(x, line), y.length)
     SILE.outputter.setFont(self.options)
     SILE.outputter.outputHbox(self.value, getNumberFromLength(self.width, line))
   end

--- a/core/math.lua
+++ b/core/math.lua
@@ -125,8 +125,8 @@ local function getNumeratorMode(mode)
   else return mathMode.scriptScriptCramped end                                                           -- S', SS' -> SS'
 end
 local function getDenominatorMode(mode)
-  if mode == mathMode.display or mode == mathMode.displayCramped then return mathMode.text           -- D, D' -> T'
-  elseif mode == mathMode.text or mode == mathMode.textCramped then return mathMode.script           -- T, T' -> S'
+  if mode == mathMode.display or mode == mathMode.displayCramped then return mathMode.textCramped    -- D, D' -> T'
+  elseif mode == mathMode.text or mode == mathMode.textCramped then return mathMode.scriptCramped    -- T, T' -> S'
   else return mathMode.scriptScriptCramped end                                                           -- S, SS, S', SS' -> SS'
 end 
 

--- a/core/math.lua
+++ b/core/math.lua
@@ -59,6 +59,9 @@ local bigOperators = {'∑','∏','⋀', '⋁', '⋂', '⋃', '⨅', '⨆'}
 -- Foward declaration
 local newSpace
 
+-- Whether to show debug boxes around mboxes
+local debug
+
 local function isCrampedMode(mode)
   return mode % 2 == 1
 end
@@ -249,6 +252,14 @@ local _mbox = _box {
   -- Output the node and all its descendants
   outputTree = function(self, x, y, line)
     self:output(x, y, line)
+    if debug and typeof(self) ~= "Space" then
+      SILE.outputter.moveTo(getNumberFromLength(x, line), y.length)
+      SILE.outputter.debugHbox(
+        { height = self.height.length,
+          depth = self.depth.length },
+        getNumberFromLength(self.width, line)
+      )
+    end
     for i, n in ipairs(self.children) do
       if n then n:outputTree(x + n.relX, y + n.relY, line) end
     end
@@ -727,6 +738,7 @@ SILE.nodefactory.math = {
 
 SILE.registerCommand("math", function (options, content)
   local mode = (options and options.mode) and options.mode or 'text'
+  debug = options and options.debug
 
   local mbox = ConvertMathML(content, mbox)
 

--- a/core/math.lua
+++ b/core/math.lua
@@ -285,6 +285,11 @@ local _stackbox = _mbox {
     if self.anchor < 1 or self.anchor > #(self.children) then
       SU.error('Wrong index of the anchor children')
     end
+  end,
+  styleChildren = function(self)
+    for i, n in ipairs(self.children) do
+      n.mode = self.mode
+    end
     if self.direction == "H" then
       -- Add space between Ord and Bin/Rel
       local spaces = {}
@@ -313,11 +318,6 @@ local _stackbox = _mbox {
         table.insert(self.children, idx, newSpace({kind = spaces[idx]}))
         if idx <= self.anchor then self.anchor = self.anchor + 1 end
       end
-    end
-  end,
-  styleChildren = function(self)
-    for i, n in ipairs(self.children) do
-      n.mode = self.mode
     end
   end,
   shape = function(self)

--- a/core/math.lua
+++ b/core/math.lua
@@ -70,9 +70,12 @@ local mathScriptConversionTable = {
 
 SILE.settings.declare({name = "math.font.family", type = "string", default = "XITS Math"})
 
-local mathCache = {}
+local mathCache
 
 local function getMathMetrics(options)
+  if mathCache then
+    return mathCache
+  end
   local face = SILE.font.cache(options, SILE.shaper.getFace)
   if not face then
     SU.error("Could not find requested font "..options.." or any suitable substitutes")
@@ -92,10 +95,11 @@ local function getMathMetrics(options)
   for k, v in pairs(mathTable.mathItalicsCorrection) do
     italicsCorrection[k] = v.value * options.size / upem
   end
-  return {
+  mathCache = {
     constants = constants,
     italicsCorrection = italicsCorrection
   }
+  return mathCache
 end
 
 -- Style transition functions for superscript and subscript

--- a/core/math.lua
+++ b/core/math.lua
@@ -314,18 +314,23 @@ local _stackbox = _mbox {
     if self.direction == "H" then
       -- Add space between Ord and Bin/Rel
       local spaces = {}
-      if self.mode == mathMode.display or self.mode == mathMode.displayCramped or
-          self.mode == mathMode.text or self.mode == mathMode.textCramped then
-        for i, v in ipairs(self.children) do
-          if i < #self.children then
-            local v2 = self.children[i + 1]
+      for i, v in ipairs(self.children) do
+        if i < #self.children then
+          local v2 = self.children[i + 1]
+          if not (isScriptMode(self.mode) or isScriptScriptMode(self.mode)) then
             if (v.atom == atomType.relationalOperator and v2.atom == atomType.ordinary) or
                 (v2.atom == atomType.relationalOperator and v.atom == atomType.ordinary) then
               spaces[i + 1] = 'thick'
             elseif (v.atom == atomType.binaryOperator and v2.atom == atomType.ordinary) or
                 (v2.atom == atomType.binaryOperator and v.atom == atomType.ordinary) then
               spaces[i + 1] = 'med'
+            elseif (v.atom == atomType.bigOperator and v2.atom == atomType.relationalOperator) or
+                (v2.atom == atomType.bigOperator and v.atom == atomType.relationalOperator) then
+              spaces[i + 1] = 'thick'
             end
+          end
+          if (v.atom == atomType.bigOperator and v2.atom == atomType.ordinary) then
+            spaces[i + 1] = 'thin'
           end
         end
       end
@@ -395,11 +400,13 @@ local _subscript = _mbox {
   base = nil,
   sub = nil,
   sup = nil,
+  atom = nil,
   init = function(self)
     _mbox.init(self)
     if self.base then table.insert(self.children, self.base) end
     if self.sub then table.insert(self.children, self.sub) end
     if self.sup then table.insert(self.children, self.sup) end
+    self.atom = self.base.atom
   end,
   styleChildren = function(self)
     if self.base then self.base.mode = self.mode end
@@ -495,6 +502,7 @@ local _subscript = _mbox {
 local _bigOpSubscript = _subscript {
   _type = "BigOpSubscript",
   kind = "sub",
+  atom = atomType.bigOperator,
   base = nil,
   sub = nil,
   sup = nil,


### PR DESCRIPTION
**NOTE: This depends on #2.**

This adds big operator support:

- [x] Typeset of a predefined list of Unicode n-ary operators (sum, product, …) as big operators when they are the base of an `msubsup` tag
- [x] In all non-display styles, display lower and upper limits as subscript and superscript to reduce the height (as in TeX)
- [x] Fix various space-related issues (see commit messages for details)
- [x] Add debug option that renders the bounding boxes of all mboxes (except spaces).
- [x] Like TeX, use a taller glyph in display style.

The supported big operators are sum, product and a few similar. Potentially, anything can be chosen to be a big operator and this can easily be made a user setting (by making the `bigOperators` list global), if we want to do that, although it might not be the cleanest way.

Example: our output (left) vs. LuaLaTeX's (right):
![Capture d’écran_2019-06-29_16-27-20](https://user-images.githubusercontent.com/14031333/60385590-f1899200-9a8a-11e9-8cb2-4f30d0622e83.png)

Obtained for the following file:
```tex
\begin[class=plain]{document}
\script[src=packages/unichar]
\begin{center}
Display math:\par
\skip[height=0.5cm]
\begin[mode=display]{math}
	\mrow{
                \msubsup{
                  \mo{∑}
                  \mrow{\mi{i}\mo{=}\mn{2}}
                  \mrow{\mi{n}}
                }
                \msub{\mi{x}\mi{i}}
                \mo{=}
                \msubsup{
                  \mo{∏}
                  \mrow{\mi{i}\mo{=}\mn{3}}
                  \mrow{\mi{m}}
                }
                \mrow{\msub{\mi{y}\mi{i}}}
                \mo{=}
                \msup{
                  \mi{j}
                  \mrow{
                    \msubsup{
                      \mo{∑}
                      \mrow{\mi{i}\mo{=}\mn{2}}
                      \mrow{\mi{n}}
                    }
                    \msubsup{\mi{x}\mi{i}\mn{2}}
                  }
                }
        }
\end{math}\par
\skip[height=.3cm]
and
\begin[mode=text]{math}
	\mrow{
                \msubsup{
                  \mo{∑}
                  \mrow{\mi{i}\mo{=}\mn{2}}
                  \mrow{\mi{n}}
                }
                \msub{\mi{x}\mi{i}}
                \mo{=}
                \msubsup{
                  \mo{∏}
                  \mrow{\mi{i}\mo{=}\mn{3}}
                  \mrow{\mi{m}}
                }
                \mrow{\msub{\mi{y}\mi{i}}}
                \mo{=}
                \msup{
                  \mi{j}
                  \mrow{
                    \msubsup{
                      \mo{∑}
                      \mrow{\mi{i}\mo{=}\mn{2}}
                      \mrow{\mi{n}}
                    }
                    \msubsup{\mi{x}\mi{i}\mn{2}}
                  }
                }
        }
\end{math}
\glue[width=1.5pt] text
\end{center}
\end{document}
```